### PR TITLE
fix calibration in analog line sensor

### DIFF
--- a/modules/@amperka/analog-line-sensor.js
+++ b/modules/@amperka/analog-line-sensor.js
@@ -7,9 +7,9 @@ var AnalogLineSensor = function(pin) {
 
 AnalogLineSensor.prototype.read = function(units) {
   if (units === 'mV') {
-    return analogRead(this._pin)*E.getAnalogVRef()*1000;
+    return analogRead(this._pin) * E.getAnalogVRef() * 1000;
   } else if (units === 'V') {
-    return analogRead(this._pin)*E.getAnalogVRef();
+    return analogRead(this._pin) * E.getAnalogVRef();
   } else if (units === 'u') {
     return analogRead(this._pin);
   } else {


### PR DESCRIPTION
Мне не понравилось, как был сделана калибровка в лайн сенсоре. Там был просто обрез по максу и мину. На самом деле нужен был map()
@niggor @r1000ru 
