### PR TITLE
Animation bug

### DIFF
--- a/modules/@amperka/animation.js
+++ b/modules/@amperka/animation.js
@@ -42,7 +42,9 @@ var Animation = function(transition) {
 };
 
 Animation.prototype.queue = function(transition) {
-  transition.from = transition.from || this._queue[this._queue.length - 1].to;
+  if (transition.from === undefined) {
+    transition.from = this._queue[this._queue.length - 1].to || 0;
+  }
   var trans = extend(
     {}, this._queue[this._queue.length - 1], transition || {});
   this._queue.push(trans);

--- a/modules/@amperka/animation.js
+++ b/modules/@amperka/animation.js
@@ -107,7 +107,7 @@ Animation.prototype._update = function() {
   var qi = this._reversed ? (qlast - this._qi) : this._qi;
   phase += dphase;
 
-  var tweakIval = false;
+  var qiChanged = false;
   if (phase > 1) {
     // phase overflow
     if (trans.loop) {
@@ -117,7 +117,7 @@ Animation.prototype._update = function() {
       // we have subsequent transition
       phase -= Math.floor(phase);
       ++qi;
-      tweakIval = true;
+      qiChanged = true;
     } else {
       // animation completed
       phase = 1;
@@ -127,7 +127,8 @@ Animation.prototype._update = function() {
 
   this._phase = this._reversed ? (1 - phase) : phase;
   this._qi = this._reversed ? (qlast - qi) : qi;
-  if (tweakIval) {
+  if (qiChanged) {
+    trans = this._queue[this._qi];
     changeInterval(
       this._intervalID,
       this._queue[this._qi].updateInterval);

--- a/modules/@amperka/animation.js
+++ b/modules/@amperka/animation.js
@@ -42,6 +42,7 @@ var Animation = function(transition) {
 };
 
 Animation.prototype.queue = function(transition) {
+  transition.from = transition.from || this._queue[this._queue.length - 1].to;
   var trans = extend(
     {}, this._queue[this._queue.length - 1], transition || {});
   this._queue.push(trans);
@@ -131,7 +132,7 @@ Animation.prototype._update = function() {
     trans = this._queue[this._qi];
     changeInterval(
       this._intervalID,
-      this._queue[this._qi].updateInterval);
+      this._queue[this._qi].updateInterval * 1000);
   }
 
   var val = lerp(this._phase, trans.from, trans.to);


### PR DESCRIPTION
@niggor @nailxx 
Animation вёл себя не так, как описано в http://wiki.amperka.ru/js:animation
2 бага:
1)В самом описании animation есть ошибка.
Текст примера:

> var myAnim = require('@amperka/animation').create({
>   from: 30,             // анимация от 30
>   to: 120,              // до 120
>   duration: 4,          // продолжительностью 4 секунды
>   updateInterval: 0.02  // с обновлением каждые 20 мс
> }).queue({
>   to: 90,               // **а сразу после этого от 120 до 90**
>   duration: 1           // продолжительностью 1 секунду
> });
> 

Мы думаем, что он пойдёт от 30 до 120 и спустится до 90.
Но, далее по тексту:

>   **Animation.queue(transition)**
> Добавляет новый переход transition в конец очереди переходов. Ожидает объект transition подобный тому, что используется в create.
> Если какие-то поля не заданы, **их значение берётся из последнего перехода в очереди**.

Именно так анимация себя вела.

Я привёл к поведению из примера. Правильно или нет? Нужно решить, как должно быть.

2) Если в анимации несколько переходов, то после первого перехода анимация идёт в 1000 раз быстрее, чем надо