### PR TITLE
Fix led.js to work with nonPWM pins. Fast fix. We need to go deeper

### DIFF
--- a/modules/@amperka/led.js
+++ b/modules/@amperka/led.js
@@ -96,7 +96,11 @@ Led.prototype.brightness = function(value) {
 
 Led.prototype._update = function() {
   var b = this._brightness;
-  analogWrite(this._pin, b * b * b * this._on, {freq: 100});
+  if (b > 0 && b < 1.0) {
+    analogWrite(this._pin, b * b * b * this._on, {freq: 100});
+  } else {
+    digitalWrite(this._pin, this._on);
+  }
 };
 
 exports.connect = function(pin) {


### PR DESCRIPTION
http://forum.amperka.ru/threads/%D0%A1%D0%BE%D0%BD%D0%B8%D0%BA.10019/#post-94001

Библиотека работает неадекватно на пинах без таймера. turnOn() не должен приводить к ошибке, если brightness = 1

Нужно решить, как мы работаем при brightness > 0 && < 1 на пинах без таймеров. У Ардуино всё просто - больше 0.5 - пишем 1, меньше - 0. А как у нас будет? вполне можем и soft:true делать