### PR TITLE
Fix _update function bug in led lib

### DIFF
--- a/modules/@amperka/led.js
+++ b/modules/@amperka/led.js
@@ -100,7 +100,7 @@ Led.prototype.brightness = function(value) {
 
 Led.prototype._update = function() {
   var b = this._brightness;
-  if (b > 0 && b < 1.0) {
+  if (b > 0 && b <= 1.0) {
     analogWrite(this._pin, b * b * b * this._on, { freq: 100 });
   } else {
     digitalWrite(this._pin, this._on);


### PR DESCRIPTION
При быстром изменении яркости с 0.2 по 0.9 на 1.0, и после вызова turnOff, не происходит выключение светодиода. Светодиод светит с той же яркостью, что была задана до смены на 1.0.

Пример программы:
```
var led = require('@amperka/led').connect(LED1);

led.turnOn();
led.brightness(0.9);
led.brightness(1.0);
led.turnOff();
```

Содержимое объекта led:
```
{ "_pin": B6, "_on": false, "_brightness": 1, "_blinkTimeoutID": null,
  "_blinkOnTime": 0, "_blinkOffTime": 0 }
```

Метод _update вызывается, но условие не выполняется.