### PR TITLE
Add release method to ServoHW

### DIFF
--- a/modules/@amperka/servo.js
+++ b/modules/@amperka/servo.js
@@ -57,6 +57,11 @@ ServoHW.prototype.write = function (value, units) {
   return this;
 };
 
+ServoHW.prototype.release = function () {
+  digitalWrite(this._pin, 0);
+  return this;
+};
+
 exports.connect = function (pin, options) {
   return new ServoHW(pin, options);
 };


### PR DESCRIPTION
### Добавил метод release для класса ServoHW

- Вызов **release** "отпускает" сервопривод
- Полсе вызова **release** можно снова звдать угол вызовом **write**

Пример использования:
```js
// Создаем новый объект Servo, подключенный к пину 13
var mServo = require('servo').connect(P13);

// Устанавливаем сервопривод на угол 90
mServo.write(90);

// Отпускаем сервопривод через 5 секунд
setTimeout(function() {
  mServo.release ();

  // Еще через 5 секунд устанавливаем сервопривод на угол 180
  setTimeout(function() {
    mServo.write(180);
  }, 5000);

}, 5000);

```